### PR TITLE
Allow request headers to be included in initial connection to server

### DIFF
--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -88,11 +88,13 @@ type WebsocketTransport struct {
 	SendTimeout    time.Duration
 
 	BufferSize int
+
+	RequestHeader http.Header
 }
 
 func (wst *WebsocketTransport) Connect(url string) (conn Connection, err error) {
 	dialer := websocket.Dialer{}
-	socket, _, err := dialer.Dial(url, nil)
+	socket, _, err := dialer.Dial(url, wst.RequestHeader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows clients to include additional headers in the initial request to the server. I've tested this, and the server does receive the expected HTTP headers on the initial connection.

This is useful for authentication, for example.