### PR TITLE
Added missing lock when reading field

### DIFF
--- a/loop.go
+++ b/loop.go
@@ -74,6 +74,9 @@ func (c *Channel) Id() string {
 Checks that Channel is still alive
 */
 func (c *Channel) IsAlive() bool {
+	c.aliveLock.Lock()
+	defer c.aliveLock.Unlock()
+
 	return c.alive
 }
 


### PR DESCRIPTION
This mutex was previously only used while writing the `alive` field.

This fixes a data race found in tests involving disconnecting the client with the `-race` flag.