### PR TITLE
Oh sorry, wrong place to put a issue!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Examples directory contains simple client and server.
 
 ### Installation
 
-    go get github.com/graarh/golang-socketio
+    go get github.com/gsocket-io/golang-socketio
 
 ### Simple server usage
 

--- a/client.go
+++ b/client.go
@@ -2,13 +2,14 @@ package gosocketio
 
 import (
 	"github.com/graarh/golang-socketio/transport"
+	"net"
 	"strconv"
 )
 
 const (
-	webSocketProtocol = "ws://"
+	webSocketProtocol       = "ws://"
 	webSocketSecureProtocol = "wss://"
-	socketioUrl       = "/socket.io/?EIO=3&transport=websocket"
+	socketioUrl             = "/socket.io/?EIO=3&transport=websocket"
 )
 
 /**
@@ -21,7 +22,7 @@ type Client struct {
 
 /**
 Get ws/wss url by host and port
- */
+*/
 func GetUrl(host string, port int, secure bool) string {
 	var prefix string
 	if secure {
@@ -29,7 +30,7 @@ func GetUrl(host string, port int, secure bool) string {
 	} else {
 		prefix = webSocketProtocol
 	}
-	return prefix + host + ":" + strconv.Itoa(port) + socketioUrl
+	return prefix + net.JoinHostPort(host, strconv.Itoa(port)) + socketioUrl
 }
 
 /**

--- a/client.go
+++ b/client.go
@@ -1,7 +1,7 @@
 package gosocketio
 
 import (
-	"github.com/graarh/golang-socketio/transport"
+	"github.com/gsocket-io/golang-socketio/transport"
 	"net"
 	"strconv"
 )

--- a/examples/client.go
+++ b/examples/client.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/graarh/golang-socketio"
-	"github.com/graarh/golang-socketio/transport"
+	"github.com/gsocket-io/golang-socketio"
+	"github.com/gsocket-io/golang-socketio/transport"
 	"log"
 	"runtime"
 	"time"

--- a/examples/server.go
+++ b/examples/server.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/graarh/golang-socketio"
-	"github.com/graarh/golang-socketio/transport"
+	"github.com/gsocket-io/golang-socketio"
+	"github.com/gsocket-io/golang-socketio/transport"
 	"log"
 	"net/http"
 	"time"

--- a/handler.go
+++ b/handler.go
@@ -2,9 +2,9 @@ package gosocketio
 
 import (
 	"encoding/json"
-	"github.com/graarh/golang-socketio/protocol"
-	"sync"
+	"github.com/gsocket-io/golang-socketio/protocol"
 	"reflect"
+	"sync"
 )
 
 const (

--- a/loop.go
+++ b/loop.go
@@ -50,7 +50,7 @@ type Channel struct {
 
 	server        *Server
 	ip            string
-	requestHeader http.Header
+	request       *http.Request
 }
 
 /**

--- a/loop.go
+++ b/loop.go
@@ -3,8 +3,8 @@ package gosocketio
 import (
 	"encoding/json"
 	"errors"
-	"github.com/graarh/golang-socketio/protocol"
-	"github.com/graarh/golang-socketio/transport"
+	"github.com/gsocket-io/golang-socketio/protocol"
+	"github.com/gsocket-io/golang-socketio/transport"
 	"net/http"
 	"sync"
 	"time"
@@ -48,9 +48,9 @@ type Channel struct {
 
 	ack ackProcessor
 
-	server        *Server
-	ip            string
-	request       *http.Request
+	server  *Server
+	ip      string
+	request *http.Request
 }
 
 /**

--- a/send.go
+++ b/send.go
@@ -3,7 +3,7 @@ package gosocketio
 import (
 	"encoding/json"
 	"errors"
-	"github.com/graarh/golang-socketio/protocol"
+	"github.com/gsocket-io/golang-socketio/protocol"
 	"log"
 	"time"
 )

--- a/server.go
+++ b/server.go
@@ -277,7 +277,11 @@ func onDisconnectCleanup(c *Channel) {
 
 		delete(c.server.rooms, c)
 	}
+	
+	go deleteSid(c)
+}
 
+func deleteSid(c *Channel) {
 	c.server.sidsLock.Lock()
 	defer c.server.sidsLock.Unlock()
 

--- a/server.go
+++ b/server.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/graarh/golang-socketio/protocol"
-	"github.com/graarh/golang-socketio/transport"
+	"github.com/gsocket-io/golang-socketio/protocol"
+	"github.com/gsocket-io/golang-socketio/transport"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -43,7 +43,7 @@ type Server struct {
 
 /**
 Close current channel
- */
+*/
 func (c *Channel) Close() {
 	if c.server != nil {
 		closeChannel(c, &c.server.methods)
@@ -284,7 +284,7 @@ func onDisconnectCleanup(c *Channel) {
 
 		delete(c.server.rooms, c)
 	}
-	
+
 	go deleteSid(c)
 }
 

--- a/server.go
+++ b/server.go
@@ -65,7 +65,14 @@ func (c *Channel) Ip() string {
 Get request header of this connection
 */
 func (c *Channel) RequestHeader() http.Header {
-	return c.requestHeader
+	return c.request.Header
+}
+
+/**
+Get request
+*/
+func (c *Channel) Request() *http.Request {
+	return c.request
 }
 
 /**
@@ -304,7 +311,7 @@ func (s *Server) SendOpenSequence(c *Channel) {
 Setup event loop for given connection
 */
 func (s *Server) SetupEventLoop(conn transport.Connection, remoteAddr string,
-	requestHeader http.Header) {
+	r *http.Request) {
 
 	interval, timeout := conn.PingParams()
 	hdr := Header{
@@ -317,7 +324,7 @@ func (s *Server) SetupEventLoop(conn transport.Connection, remoteAddr string,
 	c := &Channel{}
 	c.conn = conn
 	c.ip = remoteAddr
-	c.requestHeader = requestHeader
+	c.request = r
 	c.initChannel()
 
 	c.server = s
@@ -340,7 +347,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.SetupEventLoop(conn, r.RemoteAddr, r.Header)
+	s.SetupEventLoop(conn, r.RemoteAddr, r)
 	s.tr.Serve(w, r)
 }
 


### PR DESCRIPTION
In server examples we have:

`server := gosocketio.NewServer(transport.GetDefaultWebsocketTransport())`


But `transport.GetDefaultWebsocketTransport()` in package transport doesn't match with 

`func NewServer(tr transport.Transport) *Server ` in file server.go




Excerpt of the file [wesocket.go](https://github.com/graarh/golang-socketio/blob/master/transport/websocket.go) in package transport:

```go
/**
Returns websocket connection with default params
*/
func GetDefaultWebsocketTransport() *WebsocketTransport {
	return &WebsocketTransport{
		PingInterval:   WsDefaultPingInterval,
		PingTimeout:    WsDefaultPingTimeout,
		ReceiveTimeout: WsDefaultReceiveTimeout,
		SendTimeout:    WsDefaultSendTimeout,
		BufferSize:     WsDefaultBufferSize,
	}
}

```

Excerpt of the file [transport.go](https://github.com/graarh/golang-socketio/blob/master/transport/transport.go) in package transport:

```go
/**
Connection factory for given transport
*/
type Transport interface {
	/**
	Get client connection
	*/
	Connect(url string) (conn Connection, err error)

	/**
	Handle one server connection
	*/
	HandleConnection(w http.ResponseWriter, r *http.Request) (conn Connection, err error)

	/**
	Serve HTTP request after making connection and events setup
	*/
	Serve(w http.ResponseWriter, r *http.Request)
}
```

Excerpt of the file [server.go](https://github.com/graarh/golang-socketio/blob/master/server.go) in package gosocketio, look the parameter is `tr transport.Transport`

```go
/**
Create new socket.io server
*/
func NewServer(tr transport.Transport) *Server {
	s := Server{}
	s.initMethods()
	s.tr = tr
	s.channels = make(map[string]map[*Channel]struct{})
	s.rooms = make(map[*Channel]map[string]struct{})
	s.sids = make(map[string]*Channel)
	s.onConnection = onConnectStore
	s.onDisconnection = onDisconnectCleanup

	return &s
}
```

Excerpt of the file [server.go](https://github.com/graarh/golang-socketio/blob/master/examples/server.go) in package main directory examples, look, the parameter doesn't match with `func NewServer`

```go
func main() {
	server := gosocketio.NewServer(transport.GetDefaultWebsocketTransport())

	server.On(gosocketio.OnConnection, func(c *gosocketio.Channel) {
		log.Println("Connected")

		c.Emit("/message", Message{10, "main", "using emit"})

		c.Join("test")
		c.BroadcastTo("test", "/message", Message{10, "main", "using broadcast"})
	})
	server.On(gosocketio.OnDisconnection, func(c *gosocketio.Channel) {
		log.Println("Disconnected")
	})

	server.On("/join", func(c *gosocketio.Channel, channel Channel) string {
		time.Sleep(2 * time.Second)
		log.Println("Client joined to ", channel.Channel)
		return "joined to " + channel.Channel
	})

	serveMux := http.NewServeMux()
	serveMux.Handle("/socket.io/", server)

	log.Println("Starting server...")
	log.Panic(http.ListenAndServe(":3811", serveMux))
}
```


Thank you for attention