### PR TITLE
Add binary event support for writing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/send.go
+++ b/send.go
@@ -51,12 +51,21 @@ func send(msg *protocol.Message, c *Channel, args interface{}) error {
 Create packet based on given data and send it
 */
 func (c *Channel) Emit(method string, args interface{}) error {
-	msg := &protocol.Message{
-		Type:   protocol.MessageTypeEmit,
-		Method: method,
-	}
+	switch args.(type) {
+	case []byte:
+		if err := c.conn.WriteBinaryMessage(method, args.([]byte)); err != nil {
+			return err
+		}
 
-	return send(msg, c, args)
+		return nil
+	default:
+		msg := &protocol.Message{
+			Type:   protocol.MessageTypeEmit,
+			Method: method,
+		}
+
+		return send(msg, c, args)
+	}
 }
 
 /**

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -20,6 +20,11 @@ type Connection interface {
 	WriteMessage(message string) error
 
 	/**
+	Send binary message with event, block until sent
+	*/
+	WriteBinaryMessage(event string, message []byte) error
+
+	/**
 	Close current connection
 	*/
 	Close()


### PR DESCRIPTION
This PR adds support for writing in binary format. As can be seen from the code, it checks for passed `args` parameter in `Emit(method string, args interface{})` and if that has a `[]byte` type then a data are sending in binary format via socket according to socket.io protocol for binary messages.